### PR TITLE
Node version for the tests in Github actions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
I just saw that the Github actions failed due to my new contribution.

As far as I found, some new dependencies of NestJS v9 use some modern operators like `??`, and Node v12 doesn't support that.

With this pull request, I dropped support for Node 12, as NestJS doesn't support I believe, and added support for Node 18.

Checked it works on Github actions of my forked repository.